### PR TITLE
allow-final-layer-shape-mismatches

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,7 @@
         "pointwise",
         "poolings",
         "preds",
+        "pretrained",
         "pyclass",
         "pymethods",
         "pymodule",

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ uv run -m scripts.train_model --config-file path/to/config/file
 ### Config file 
 The config file for training defines the fields that are passed to the corresponding factories in the code. This way one can configure multiple training runs without having to change the source code. See configs/RTMDer_training_config.template.yaml for an example how the config file should look like. See the factory methods in the source code for details on their arguments.
 
+In model_cfg, if you set strict to false, you can use pretrained RTMDet weights with a different number of output classes as your models initial weights since make model takes care of resizing mismatching shapes automatically. See src/rtmdet_object_detection_dev/model/model.py for details.
+
 ### Dataset
 As an example, I have used the Oxford-IIT Pet Dataset (https://www.robots.ox.ac.uk/~vgg/data/pets/). If you want to use your own dataset just add a dataset implementation to src/rtmdet_object_detection_dev/datasets and add it to the dataset_factory.py. The rest of this subsection covers the Oxford-IIT Pet Dataset.
 

--- a/configs/RTMDet_training_config.template.yaml
+++ b/configs/RTMDet_training_config.template.yaml
@@ -9,7 +9,8 @@ train_config:
   model_cfg:
     model_name: "RTMDetTiny"
     num_classes: *num_classes 
-    model_weights: # model_weights/RTMDetTiny-coco.pth
+    model_weights: model_weights/RTMDetTiny-coco.pth
+    strict: false
 
   training_dataloader_config:
     dataset_configs:

--- a/src/rtmdet_object_detection_dev/model/model.py
+++ b/src/rtmdet_object_detection_dev/model/model.py
@@ -1,13 +1,56 @@
 import torch
 import torch.nn as nn
+from collections import OrderedDict
 
 from .rtmdet_models import RTMDet
+
+
+def load_state_dict_with_resizing(
+    model: nn.Module, weights_state_dict: dict[str, torch.Tensor]
+) -> None:
+    """
+    Load the matching weights in the state dict to the model. If the shape does not match
+    resizes the weights to match to the model's shape. Ignores missing or extra weights.
+    """
+    model_state_dict: dict[str, torch.Tensor] = model.state_dict()
+
+    resized_dict = OrderedDict()
+    for k, v in weights_state_dict.items():
+        if k not in model_state_dict:
+            continue
+
+        if model_state_dict[k].shape == v.shape:
+            resized_dict[k] = v
+            continue
+
+        old_shape = v.shape
+        new_shape = model_state_dict[k].shape
+
+        if len(v.shape) == 4:
+            out_channels = min(old_shape[0], new_shape[0])
+            resized = v[:out_channels, : new_shape[1], : new_shape[2], : new_shape[3]]
+            padded = torch.zeros(new_shape)
+            padded[: resized.shape[0]] = resized
+            resized_dict[k] = padded
+            continue
+
+        if len(v.shape) == 1:
+            resized = v[: new_shape[0]]
+            padded = torch.zeros(new_shape)
+            padded[: resized.shape[0]] = resized
+            resized_dict[k] = padded
+            continue
+
+        raise RuntimeError(f"Resizing of key {k} with shape {v.shape} not supported.")
+
+    model.load_state_dict(resized_dict, strict=False)
 
 
 def make_model(
     model_name: str,
     num_classes: int,
     model_weights: str | None,
+    strict: bool = True,
     eval: bool = True,
     raw_output: bool = False,
 ) -> nn.Module:
@@ -16,6 +59,7 @@ def make_model(
     - model_name: name of the model, e.g., 'RTMDetTiny'
     - num_classes: the number of classes that the model should predict.
     - model_weights: path to the model weight file. If None, no weights are loaded.
+    - strict: bool that tells if weights should be loaded strictly, i.e., with perfect compatibility with the model.
     - eval: bool that tells if the model should be set to eval mode.
     - raw_output: if true returns outputs as a tuple of classification output tuple and regression output tuple instead of the
                     RTMDetOutput class. Used when converting to onnx.
@@ -65,7 +109,11 @@ def make_model(
         raise ValueError(f"Invalid model name '{model_name}'.")
 
     if model_weights is not None:
-        model.load_state_dict(torch.load(model_weights, weights_only=True), strict=True)
+        weights_state_dict = torch.load(model_weights, weights_only=True)
+        if strict:
+            model.load_state_dict(weights_state_dict, strict=True)
+        else:
+            load_state_dict_with_resizing(model, weights_state_dict)
 
     if eval:
         model.eval()


### PR DESCRIPTION
Allow pretrained weights to have different shape than the model requires. Useful when training a model that should predict a different number of output classes than the pretrained models. 