### PR TITLE
Fix image reading bug in demo scripts

### DIFF
--- a/scripts/convert_to_onnx.py
+++ b/scripts/convert_to_onnx.py
@@ -1,7 +1,7 @@
 """A script that is used to convert trained RTMDet models to ONNX format.
 
 Example usage:
-uv run -m scripts.convert_to_onnx --model-name RTMDetM --num_classes 80 --model-weights model_weights/RTMDetM-coco.pth
+uv run -m scripts.convert_to_onnx --model-name RTMDetM --num-classes 80 --model-weights model_weights/RTMDetM-coco.pth
 --output-name RTMDetM-coco
 """
 
@@ -24,7 +24,7 @@ def main() -> None:
         help="Name of the model. E.g., RTMDetTiny",
     )
     parser.add_argument(
-        "--num_classes",
+        "--num-classes",
         required=True,
         type=int,
         help="The number of classes the model predicts",

--- a/scripts/inference_python.py
+++ b/scripts/inference_python.py
@@ -122,7 +122,10 @@ def main() -> None:
 
     with torch.inference_mode():
         for image_file_batch in batch_image_files(image_file_generator, args.batch_size):
-            images = [torchvision.io.read_image(str(file_path)).float() for file_path in image_file_batch]
+            images = [
+                torchvision.io.read_image(str(file_path), torchvision.io.ImageReadMode.RGB).float()
+                for file_path in image_file_batch
+            ]
 
             input_batch = preprocess_images_to_batch(images, preprocessor)
             model_output = model(input_batch)

--- a/scripts/inference_rust.py
+++ b/scripts/inference_rust.py
@@ -102,7 +102,10 @@ def main() -> None:
     image_file_generator = chain(input_dir.glob("*.jpg"), input_dir.glob("*.png"))
 
     for image_file_batch in batch_image_files(image_file_generator, args.batch_size):
-        images = [torchvision.io.read_image(str(file_path)) for file_path in image_file_batch]
+        images = [
+            torchvision.io.read_image(str(file_path), torchvision.io.ImageReadMode.RGB)
+            for file_path in image_file_batch
+        ]
         images_np = [image.permute(1, 2, 0).numpy() for image in images]
 
         detection_results = detector.detect_from_numpy(images_np)


### PR DESCRIPTION
Specify that all images are read as rgb in the demo scripts and remove underscores from cli arguments