### PR TITLE
Fix SPPFBottleneck forward to apply pooling layers in parallel

### DIFF
--- a/src/rtmdet_object_detection_dev/model/basic_components.py
+++ b/src/rtmdet_object_detection_dev/model/basic_components.py
@@ -193,11 +193,7 @@ class SPPFBottleneck(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Perform module calculations."""
-        x = self.conv1(x)
-        pooling1 = self.poolings[0](x)
-        pooling2 = self.poolings[1](pooling1)
-        pooling3 = self.poolings[2](pooling2)
-
-        out = torch.concat([x, pooling1, pooling2, pooling3], dim=1)
-
+        x = self.conv1(x) 
+        pooled = [pool(x) for pool in self.poolings]
+        out = torch.cat([x] + pooled, dim=1)
         return self.conv2(out)


### PR DESCRIPTION
## Description
This PR fixes the `SPPFBottleneck` implementation where pooling layers were applied **sequentially** instead of in **parallel**.  

### Fix
Updated the forward method so that all pooling layers take the same x (after conv1) as input.

### Related Issue
Closes #20 
