### PR TITLE
Revert "Fix SPPFBottleneck forward to apply pooling layers in parallel"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ If you’re interested in understanding how the detector works, I recommend read
 
 In my master’s thesis, I used RTMDet-Tiny and provided a detailed explanation of its implementation in subsections 3.1.1–3.1.4. You can find the thesis here: (https://aaltodoc.aalto.fi/items/ceb91022-2998-4c0c-a9c1-9ed64250aca6). Please note that my thesis may contain some errors. Below are a few corrections I’ve identified:
 - Figure 7: The DWConvModule is missing the pointwise convolution.
-- Figure 7: The SPPFBottleneck should apply the pooling layers in parallel instead of sequentially.
 - Figure 8: The second output should be a Conv2D, not a ConvModule.
 - Algorithm 4: The cost vector should be sorted in ascending order, not descending.
 

--- a/src/rtmdet_object_detection_dev/model/basic_components.py
+++ b/src/rtmdet_object_detection_dev/model/basic_components.py
@@ -176,13 +176,7 @@ class SPPFBottleneck(nn.Module):
             stride=1,
             padding=0,
         )
-        self.poolings = nn.ModuleList(
-            [
-                nn.MaxPool2d(kernel_size=5, stride=1, padding=2, dilation=1, ceil_mode=False),
-                nn.MaxPool2d(kernel_size=9, stride=1, padding=4, dilation=1, ceil_mode=False),
-                nn.MaxPool2d(kernel_size=13, stride=1, padding=6, dilation=1, ceil_mode=False),
-            ],
-        )
+        self.pooling = nn.MaxPool2d(kernel_size=5, stride=1, padding=2, dilation=1, ceil_mode=False)
         self.conv2 = ConvModule(
             (in_channels // 2) * 4,
             out_channels=in_channels,
@@ -194,9 +188,10 @@ class SPPFBottleneck(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Perform module calculations."""
         x = self.conv1(x)
-        pooling1 = self.poolings[0](x)
-        pooling2 = self.poolings[1](pooling1)
-        pooling3 = self.poolings[2](pooling2)
+
+        pooling1 = self.pooling(x)
+        pooling2 = self.pooling(pooling1)
+        pooling3 = self.pooling(pooling2)
 
         out = torch.concat([x, pooling1, pooling2, pooling3], dim=1)
 

--- a/src/rtmdet_object_detection_dev/model/basic_components.py
+++ b/src/rtmdet_object_detection_dev/model/basic_components.py
@@ -194,6 +194,10 @@ class SPPFBottleneck(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Perform module calculations."""
         x = self.conv1(x)
-        pooled = [pool(x) for pool in self.poolings]
-        out = torch.cat([x, *pooled], dim=1)
+        pooling1 = self.poolings[0](x)
+        pooling2 = self.poolings[1](pooling1)
+        pooling3 = self.poolings[2](pooling2)
+
+        out = torch.concat([x, pooling1, pooling2, pooling3], dim=1)
+
         return self.conv2(out)


### PR DESCRIPTION
Reverts JVT47/RTMDet-object-detection#21

In SPPF the idea is to do the maxpools sequentially rather than in parallel as this is faster than the SPP implementation used in the original RTMDet implementation. Note that the outputs of the SPPF and SPP blocks are the same so SPPF can safely replace the SPP block.

However, there was a bug with the kernel sizes and paddings of the max pool layers. 